### PR TITLE
Use "with" instead of "assert"

### DIFF
--- a/denops/@ddu-sources/emoji.ts
+++ b/denops/@ddu-sources/emoji.ts
@@ -4,7 +4,7 @@ import {
   type GatherArguments,
 } from "https://deno.land/x/ddu_vim@v3.4.3/base/source.ts";
 import type { Item } from "https://deno.land/x/ddu_vim@v3.4.3/types.ts";
-import EMOJIS from "https://unpkg.com/unicode-emoji-json@0.5.0/data-by-emoji.json" assert {
+import EMOJIS from "https://unpkg.com/unicode-emoji-json@0.5.0/data-by-emoji.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
Using deno 1.46.1 with [denops latest](https://github.com/vim-denops/denops.vim/blob/45b8a1c45fe06e95538fc701ee7d6e3cc5335659/README.md), we get an error like below:

```
[denops] ⚠️  Import assertions are deprecated. Use `with` keyword, instead of 'assert' keyword.
[denops] 
[denops] import EMOJIS from "https://unpkg.com/unicode-emoji-json@0.5.0/data-by-emoji.json" assert {
[denops]   type: "json",
[denops] };
[denops] 
[denops]   at file:///home/kyoh86/.local/share/nvim/lazy/ddu-source-emoji/denops/@ddu-sources/emoji.ts:7:1
[denops] 
```
